### PR TITLE
fix linuxtv git url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "data/dtv-scan-tables"]
 	path = data/dtv-scan-tables
-	url = https://git.linuxtv.org/cgit.cgi/dtv-scan-tables.git
+	url = https://git.linuxtv.org/dtv-scan-tables.git


### PR DESCRIPTION
Upgrade deprecated git repository url which made "git submodule update" command to fail.