### PR TITLE
fix race condition during stream exit and a fast subsequent setup/play request

### DIFF
--- a/src/Dvb/TSStream.php
+++ b/src/Dvb/TSStream.php
@@ -90,6 +90,11 @@ class TSStream extends EventEmitter
      */
     private $channels;
 
+    /**
+     * @var Exiting
+     * Indicating exit process started. This process depends on termination delay.
+     */
+    private $exiting = false;
     private $exited = false;
 
     /**
@@ -276,6 +281,7 @@ class TSStream extends EventEmitter
 
         $this->emit('exit');
         $this->removeAllListeners();
+        $this->exiting = false;
     }
 
     /**
@@ -431,6 +437,15 @@ class TSStream extends EventEmitter
     }
 
     /**
+     * Return the exiting status
+     * @return bool
+     */
+    public function isExiting()
+    {
+        return $this->exiting;
+    }
+
+    /**
      * Terminate process forcefully
      */
     public function terminate()
@@ -438,6 +453,7 @@ class TSStream extends EventEmitter
         if ($this->exited) {
             return;
         }
+        $this->exiting = true;
         $this->logger->debug("Terminate process " . $this->process->getCommand());
         if (!$this->process->terminate(SIGKILL)) {
             throw new \RuntimeException("Unable to signal process");


### PR DESCRIPTION
I experienced issues during channel switching from VLC player. When termination of dvb process is longer than the RTSP next setup/play request, a race condition occurred which made the setup/play request to be ignored.

This commit fix this by managing an exiting status that is checked in the setup/play request evaluation.