### PR TITLE
Fix syntax error if channel's name has quote

### DIFF
--- a/src/Dvb/Channels.php
+++ b/src/Dvb/Channels.php
@@ -75,7 +75,7 @@ class Channels
                 throw new ChannelsNotFoundException("{$this->filepath} is not a file");
             }
 
-            $this->channelsByName = parse_ini_file($this->filepath, true);
+            $this->channelsByName = parse_ini_file($this->filepath, true, INI_SCANNER_RAW);
             if ($this->channelsByName === false) {
                 throw new ChannelsNotFoundException("{$this->filepath} is not a valid channel file");
             }

--- a/src/Pages/Channels/M3u8.php
+++ b/src/Pages/Channels/M3u8.php
@@ -72,7 +72,7 @@ class M3u8 extends AbstractChannelsController
         }
 
         foreach ($channels as $channelDescriptor) {
-            $content .= "#EXTINF:-1 tvg-id=\"{$channelDescriptor['SERVICE_ID']}\",{$channelDescriptor['NAME']}\r\n";
+            $content .= "#EXTINF:-1 tvg-id=\"{$channelDescriptor['SERVICE_ID']}\",{$channelDescriptor['NAME']->replace("'","")}\r\n";
             $content .= "rtsp://{$host}:{$this->rtspPort}/{$channelDescriptor['SERVICE_ID']}\r\n";
         }
 

--- a/src/Pages/Channels/M3u8.php
+++ b/src/Pages/Channels/M3u8.php
@@ -72,7 +72,7 @@ class M3u8 extends AbstractChannelsController
         }
 
         foreach ($channels as $channelDescriptor) {
-            $content .= "#EXTINF:-1 tvg-id=\"{$channelDescriptor['SERVICE_ID']}\",{$channelDescriptor['NAME']->replace("'","")}\r\n";
+            $content .= "#EXTINF:-1 tvg-id=\"{$channelDescriptor['SERVICE_ID']}\",{$channelDescriptor['NAME']}\r\n";
             $content .= "rtsp://{$host}:{$this->rtspPort}/{$channelDescriptor['SERVICE_ID']}\r\n";
         }
 


### PR DESCRIPTION
Channels with quotes (example: L'Equipe) throw a syntax error when server read channels.conf . Quotes need also to be removed when reading m3u8 file to play the channel