### PR TITLE
Fix sh: Syntax error when playing channels with a quote mark

### DIFF
--- a/src/ProcessAdapter/DvbzapProcessAdapter.php
+++ b/src/ProcessAdapter/DvbzapProcessAdapter.php
@@ -66,7 +66,7 @@ class DvbzapProcessAdapter extends AbstractProcessAdapter implements TunerProces
         }
         $channelsFilePath = $this->channels->getChannelsFilePath();
         $channelName = $channelDescriptor['NAME'];
-        $processLine = "exec dvbv5-zap -c {$channelsFilePath} -v --lna=-1 '{$channelName}' -P -o -";
+        $processLine = "exec dvbv5-zap -c {$channelsFilePath} -v --lna=-1 \"{$channelName}\" -P -o -";
         $this->logger->debug("Starting $processLine");
         return new Process($processLine);
     }


### PR DESCRIPTION
Fix issue  [#8](https://github.com/phpbg/watchtv/issues/8)  about the problem of playing channels with a quote mark in the name